### PR TITLE
Wrong instruction on missing third-party packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.rst
+recursive-include vaurien .txt
+recursive-include docs *.*


### PR DESCRIPTION
I think that it's easier to reproduce, than to explain:

```
$ vaurien --http --http-port 8099
2012-10-24 13:32:14 [29091] [INFO] Starting the Chaos TCP Server
2012-10-24 13:32:14 [29091] [INFO] localhost:8000 => localhost:80
Traceback (most recent call last):
  File "/usr/local/bin/vaurien", line 9, in <module>
    load_entry_point('vaurien==0.1', 'console_scripts', 'vaurien')()
  File "/usr/local/lib/python2.6/dist-packages/vaurien-0.1-py2.6.egg/vaurien/run.py", line 130, in main
    from vaurien.webserver import app
  File "/usr/local/lib/python2.6/dist-packages/vaurien-0.1-py2.6.egg/vaurien/webserver.py", line 14, in <module>
    + '%s"\nInitial error: %s' % (reqs, str(e)))
ImportError: You need some dependencies to run the web interface. You can do so by using "pip install -r /usr/local/lib/python2.6/dist-packages/vaurien-0.1-py2.6.egg/vaurien/web-requirements.txt"
Initial error: No module named flask
$ sudo pip install -r /usr/local/lib/python2.6/dist-packages/vaurien-0.1-py2.6.egg/vaurien/web-requirements.txt
...
IOError: [Errno 2] No such file or directory: '/usr/local/lib/python2.6/dist-packages/vaurien-0.1-py2.6.egg/vaurien/web-requirements.txt'
```
