### PR TITLE
Fixed runtime error in RandomProxy.get_handler

### DIFF
--- a/vaurien/proxy.py
+++ b/vaurien/proxy.py
@@ -125,10 +125,11 @@ class RandomProxy(DefaultProxy):
                 choices['normal'] = normal, missing
 
         for name, (handler, percent) in choices.items():
-            self.choices.extend([self.handlers[name] for i in range(percent)])
+            self.choices.extend(
+                [(self.handlers[name], name) for i in range(percent)])
 
     def get_handler(self):
-        return random.choice(self.choices.items())
+        return random.choice(self.choices)
 
 
 class OnTheFlyProxy(DefaultProxy):


### PR DESCRIPTION
There was a runtime error if the RandomProxy was selected (running without `--http` option).

```
Traceback (most recent call last):
  File "/usr/local/lib/python2.6/dist-packages/gevent-0.13.8-py2.6-linux-x86_64.egg/gevent/greenlet.py", line 390, in run
    result = self._run(*self.args, **self.kwargs)
  File "/usr/local/lib/python2.6/dist-packages/vaurien-0.1-py2.6.egg/vaurien/proxy.py", line 46, in handle
    handler, handler_name = self.get_handler()
  File "/usr/local/lib/python2.6/dist-packages/vaurien-0.1-py2.6.egg/vaurien/proxy.py", line 131, in get_handler
    return random.choice(self.choices.items())
AttributeError: 'list' object has no attribute 'items'
<Greenlet at 0x1993cd0: <bound method RandomProxy.handle of <RandomProxy at 0x1a310d0 fileno=3 address=127.0.0.1:5555>>(<socket at 0x1a4e4d0 fileno=4 sock=127.0.0.1:5555, ('127.0.0.1', 46959))> failed with AttributeError
```
