### PR TITLE
Fix four HTTP proxying problems.

### DIFF
--- a/vaurien/behaviors/error.py
+++ b/vaurien/behaviors/error.py
@@ -31,6 +31,7 @@ _ERROR_CODES = _ERRORS.keys()
 _TMP = """\
 HTTP/1.1 %(code)s %(name)s
 Content-Type: text/html; charset=UTF-8
+Connection: close
 
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
 <title>%(code)s %(name)s</title>

--- a/vaurien/protocols/http.py
+++ b/vaurien/protocols/http.py
@@ -18,6 +18,13 @@ class Http(BaseProtocol):
     """
     name = 'http'
 
+    def _close_both(self, source, dest):
+        source.close()
+        source._closed = True
+        dest.close()
+        dest._closed = True
+        return False
+
     def _handle(self, source, dest, to_backend):
         buffer_size = self.option('buffer')
 
@@ -26,35 +33,37 @@ class Http(BaseProtocol):
         while not parser.is_message_complete():
             data = self._get_data(source, buffer_size)
             if not data:
-                self._abort_handling(to_backend, dest)
-                return False
+                return self._close_both(source, dest)
             nparsed = parser.execute(data, len(data))
             assert nparsed == len(data)
             data = HOST_REPLACE.sub('\r\nHost: %s\r\n'
                                     % self.proxy.backend, data)
             dest.sendall(data)
+        keep_alive_src = parser.should_keep_alive()
+        method = parser.get_method()
 
         # Getting the HTTP response and sending it back to the source.
         parser = HttpParser()
-        while not parser.is_message_complete():
+        while not (parser.is_message_complete() or
+                   (method == 'HEAD' and parser.is_headers_complete())):
             data = self._get_data(dest, buffer_size)
             if not data:
-                self._abort_handling(to_backend, dest)
-                return False
+                return self._close_both(source, dest)
             nparsed = parser.execute(data, len(data))
             assert nparsed == len(data)
             source.sendall(data)
-
-        keep_alive = parser.should_keep_alive()
+        keep_alive_dst = parser.should_keep_alive()
 
         # do we close the client ?
-        if not keep_alive and not self.option('keep_alive'):
+        if not keep_alive_src or not self.option('keep_alive'):
             source.close()
             source._closed = True
 
-        if not self.option('reuse_socket') and not self.option('keep_alive'):
+        if (not keep_alive_dst or
+            not self.option('reuse_socket') or
+            not self.option('keep_alive')):
+
             dest.close()
             dest._closed = True
 
-        # we're done
-        return keep_alive or self.option('keep_alive')
+        return keep_alive_dst and self.option('keep_alive')

--- a/vaurien/proxy.py
+++ b/vaurien/proxy.py
@@ -206,6 +206,12 @@ class RandomProxy(DefaultProxy):
             self.choices.extend(
                 [(self.behaviors[name], name) for i in range(percent)])
 
+    def _weirdify(self, client_sock, backend_sock, to_backend,
+                  statsd_prefix, behavior, behavior_name):
+      behavior, behavior_name = self.get_behavior()
+      super(RandomProxy, self)._weirdify(client_sock, backend_sock, to_backend,
+                                         statsd_prefix, behavior, behavior_name)
+
     def get_behavior(self):
         return random.choice(self.choices)
 


### PR DESCRIPTION
- Added "Connection: close" to 5xx errors.
- Properly close both upstream and downstream connections on errors.
- Fixed infinite loop when responding to HEAD requests that have no body.
- Fixed randomness when using keep-alive connections. Previously, the behavior
  was only randomly selected on new connections, but HTTP keep-alive connections
  need to choose a random behavior for each new request/response.
