### PR TITLE
Return proper value from _weirdify()

### DIFF
--- a/vaurien/proxy.py
+++ b/vaurien/proxy.py
@@ -209,9 +209,9 @@ class RandomProxy(DefaultProxy):
     def _weirdify(self, client_sock, backend_sock, to_backend,
                   statsd_prefix, behavior, behavior_name):
         behavior, behavior_name = self.get_behavior()
-        super(RandomProxy, self)._weirdify(client_sock, backend_sock,
-                                           to_backend, statsd_prefix,
-                                           behavior, behavior_name)
+        return super(RandomProxy, self)._weirdify(client_sock, backend_sock,
+                                                  to_backend, statsd_prefix,
+                                                  behavior, behavior_name)
 
     def get_behavior(self):
         return random.choice(self.choices)


### PR DESCRIPTION
My attempts to use --protocol=mysql were being terminated prematurely.  I think this was because RandomProxy._weirdify was always returning a falsy value, which means "terminate the connection".  This fix makes --protocol=mysql work well for me.
