### PR TITLE
Bug fix and typo

### DIFF
--- a/vaurien/proxy.py
+++ b/vaurien/proxy.py
@@ -40,8 +40,8 @@ class DefaultProxy(StreamServer):
         self._statsd = statsd
         self._logger = logger
         self.behaviors = behaviors
-        self.behaviors.update(get_prefixed_sections(self.settings, logger,
-                                                    'behavior'))
+        self.behaviors.update(get_prefixed_sections(self.settings, 'behavior',
+                                                    logger))
         self.behavior = get_behaviors()['dummy']
         self.behavior_name = 'dummy'
         self.stay_connected = cfg.get('stay_connected', False)
@@ -50,8 +50,8 @@ class DefaultProxy(StreamServer):
 
         # creating the handler with the passed options
         protocols = get_protocols()
-        protocols.update(get_prefixed_sections(self.settings, logger,
-                                               'protocol'))
+        protocols.update(get_prefixed_sections(self.settings, 'protocol',
+                                               logger))
 
         self.handler = protocols[self.protocol]
 


### PR DESCRIPTION
Hi,

I came across two issues while using vaurien.

First, given the following configuration file

[vaurien]
proxy = localhost:6432
backend = localhost:5432
protocol = tcp
stay_connected = true

[protocol:tcp]
keep_alive = true
(...)

The protocol specific options of the [protocol:tcp] section were ignored.
The proposed fix consists in updating the handler's settings using the appropriate section prefix right after the use of command line provided protocol arguments.

Second, while investigating the first issue, i have noticed that the use of get_prefixed_sections in proxy.py differs from its declaration found in util.py (wrong parameter order regarding the prefix and the logger).
