### PR TITLE
setting the timeout value on the client socket

### DIFF
--- a/vaurien/proxy.py
+++ b/vaurien/proxy.py
@@ -85,6 +85,7 @@ class DefaultProxy(StreamServer):
 
     def handle(self, client_sock, address):
         client_sock.setblocking(0)
+        client_sock.settimeout(self.timeout)
         behavior, behavior_name = self.get_behavior()
 
         statsd_prefix = '%s.%s.' % (self.protocol, uuid4())


### PR DESCRIPTION
this prevents gevent's sendall method from exploding when the
response is big enough to take multiple calls to send.

found that the proxy would choke when attempting to stream a large (255kb) http response to a laggy(ish) client. 

```
2014-01-31 20:37:30 [24996] [DEBUG] exiting weirdify True
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/gevent/greenlet.py", line 327, in run
    result = self._run(*self.args, **self.kwargs)
  File "/home/gadavis/vaurien/vaurien/proxy.py", line 215, in _weirdify
    behavior, behavior_name)
  File "/home/gadavis/vaurien/vaurien/proxy.py", line 163, in _weirdify
    return self.handler(source, dest, to_backend, behavior)
  File "/home/gadavis/vaurien/vaurien/protocols/base.py", line 58, in __call__
    return self._handle(source, dest, to_backend)
  File "/home/gadavis/vaurien/vaurien/protocols/http.py", line 62, in _handle
    source.sendall(data)
  File "/usr/local/lib/python2.7/site-packages/gevent/socket.py", line 471, in sendall
    raise timeout('timed out')
```

after adding some debugging to `socket.py` I found that the timeout value is in fact zero, hence the patch.

I haven't been able to work out a suitable automatic test case as yet.
