### PR TITLE
changed delay to use a float instead of int

### DIFF
--- a/vaurien/behaviors/delay.py
+++ b/vaurien/behaviors/delay.py
@@ -8,7 +8,7 @@ class Delay(Dummy):
     The delay can happen *after* or *before* the backend is called.
     """
     name = 'delay'
-    options = {'sleep': ("Delay in seconds", int, 1),
+    options = {'sleep': ("Delay in seconds (float)", float, 1),
                'before':
                ("If True adds before the backend is called. Otherwise"
                 " after", bool, True)}


### PR DESCRIPTION
This patch just changes the delay parameter to use a float instead of int so that fractional second delays can be tested.

The underlying gevent.sleep accepts floats:  http://www.gevent.org/gevent.html#gevent.sleep
