### PR TITLE
The default value for the overwrite-host-header option should be False

### DIFF
--- a/vaurien/protocols/http.py
+++ b/vaurien/protocols/http.py
@@ -20,7 +20,7 @@ class Http(BaseProtocol):
     options = copy.copy(BaseProtocol.options)
     options['overwrite_host_header'] = ("If True, the HTTP Host header will "
                                         "be rewritten with backend address.",
-                                        bool, True)
+                                        bool, False)
 
     def _close_both(self, source, dest):
         source.close()


### PR DESCRIPTION
The default value for the overwrite-host-header is True therefore there is no way to turn off this. Changed the default to False.
