### PR TITLE
Fixing bug with caching overriding behaviors coming in from the REST API

### DIFF
--- a/vaurien/proxy.py
+++ b/vaurien/proxy.py
@@ -161,9 +161,10 @@ class DefaultProxy(StreamServer):
         self._logger.debug('starting weirdify %s' % to_backend)
         try:
             # XXX cache this ?
-            args = self.settings['args']
-            behavior.update_settings(extract_settings(args, 'behavior',
-                                                      behavior_name))
+            # Caching is bad!  Does not allow overriding behaviors from the REST API!!
+            # args = self.settings['args']
+            # behavior.update_settings(extract_settings(args, 'behavior',
+            #                                           behavior_name))
             # calling the handler
             return self.handler(source, dest, to_backend, behavior)
         finally:


### PR DESCRIPTION
Obviously you may want to fix this more appropriately.  This breaks the REST API for setting behaviors, which is critical for my use case.  Would love to see a version I don't have to patch manually in my instances, so submitting back a patch to remove this caching functionality.