### PR TITLE
Ensure timeout is set on new sockets.

### DIFF
--- a/vaurien/proxy.py
+++ b/vaurien/proxy.py
@@ -78,6 +78,7 @@ class DefaultProxy(StreamServer):
         conn = create_connection(self.dest, timeout=self.timeout)
         if self.async_mode:
             conn.setblocking(0)
+            conn.settimeout(self.timeout)
         return conn
 
     def get_behavior(self):

--- a/vaurien/tests/test_proxy.py
+++ b/vaurien/tests/test_proxy.py
@@ -32,7 +32,7 @@ class TestSimpleProxy(unittest.TestCase):
         self._web.terminate()
 
     def test_existing_behaviors(self):
-        wanted = ['blackout', 'delay', 'dummy', 'error', 'hang', 'transient', 'abort']
+        wanted = ['abort', 'blackout', 'delay', 'dummy', 'error', 'hang', 'transient']
         self.assertEqual(self.client.list_behaviors(), wanted)
 
     def test_proxy(self):


### PR DESCRIPTION
 Fixes mozilla-services/vaurien#51 and mozilla-services/vaurien#52
